### PR TITLE
filter out PR author from persons assignment

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -40,7 +40,11 @@ export async function run() {
     }
 
     const teams = core.getInput('teams').split(',').map(a => a.trim())
-    const persons = core.getInput('persons').split(',').map(a => a.trim())
+    const persons = core.getInput('persons')
+      .split(',')
+      // filter out PR creator
+      .filter(user => user !== pull.data.user.login)
+      .map(a => a.trim())
     
     if(teams.length == 0 && persons.length == 0){
       core.setFailed("Please specify 'teams' and/or 'persons'")

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,7 +43,7 @@ export async function run() {
     const persons = core.getInput('persons')
       .split(',')
       // filter out PR creator
-      .filter(user => user !== pull.data.user.login)
+      .filter(user => user !== issue.owner)
       .map(a => a.trim())
     
     if(teams.length == 0 && persons.length == 0){


### PR DESCRIPTION
Ran into a problem when using the `persons` list where someone from the list creates a PR which then errors with:

```
##[error]Review cannot be requested from pull request author.
```

To work around that, this PR filters out the PR author from the `persons` list before moving on.

_Note: not sure how to test this, but it should work™_ 