### PR TITLE
Fix 'Example Usage' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Assign Team and Persons"
-      uses: rowi1de/auto-assign-review-teams@v1.0.1
+      uses: rowi1de/auto-assign-review-teams@v.1.0.1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         teams: "gitub-org-team"         # only works for GitHub Organisation/Teams


### PR DESCRIPTION
I tried this action but I couldn't run it.

![image](https://user-images.githubusercontent.com/2035364/98818478-faf08000-246e-11eb-8708-5df84959441b.png)

It seems that a typo were made in Example Usage in README.md.

